### PR TITLE
Fix docker python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.3-slim-buster
+FROM python:3.11-slim
 
 LABEL "maintainer"="Scott Ng <thuongnht@gmail.com>"
 LABEL "repository"="https://github.com/cross-the-world/ssh-pipeline"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.8-slim-bookworm
 
 LABEL "maintainer"="Scott Ng <thuongnht@gmail.com>"
 LABEL "repository"="https://github.com/cross-the-world/ssh-pipeline"


### PR DESCRIPTION
The action fails to build because python:3.8.3-slim-buster uses Debian Buster repositories which are now archived and return 404 errors. Updated to python:3.8-slim-bookworm to use active repositories while maintaining compatibility.